### PR TITLE
Gracefully handle 429 errors from the WorkOS API

### DIFF
--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Updates the script to gracefully handle any rate limit errors, pausing execution of the queue (respecting the `Retry-After` header), and then resuming any tasks that fails.