### PR TITLE
Handle missing email

### DIFF
--- a/src/auth0-exported-user.ts
+++ b/src/auth0-exported-user.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
  */
 export const Auth0ExportedUser = z.object({
   Id: z.string(),
-  Email: z.string(),
+  Email: z.optional(z.string()),
   "Email Verified": z.optional(z.boolean()),
   "Given Name": z.optional(z.string()),
   "Family Name": z.optional(z.string()),

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,10 @@ async function findOrCreateUser(
   exportedUser: Auth0ExportedUser,
   passwordHash: string | undefined,
 ) {
+  if (!exportedUser.Email) {
+    return null;
+  }
+
   try {
     const passwordOptions = passwordHash
       ? {


### PR DESCRIPTION
It's possible for `Email` to be missing in exported lines from Auth0. Let's handle it by ignoring those users (right now the tool crashes)